### PR TITLE
Update the specification to use HTTP HEAD instead of HTTP GET

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -76,20 +76,20 @@ provide a [=payment method manifest=] file in JSON format containing two key pie
 
 <h3 id="accessing">Accessing the manifest</h3>
 
-The machine-readable [=payment method manifest=] might be found either directly at the
-[=payment method identifier=] URL, or in a location indicated indirectly by following a HTTP
-`<code>Link</code>` header from that URL. [[RFC8288]]
+The machine-readable [=payment method manifest=] can be found in a location
+indicated by following the HTTP `<code>Link</code>` header from the [=payment
+method identifier=] URL. [[RFC8288]]
 
-This potential indirection allows the use of generic, human-readable URLs (such as
-"<code>https://alicepay.com/</code>") to serve as [=payment method identifiers=], while still
+This indirection allows the use of generic, human-readable URLs (such as
+"<code>https://alicepay.com/</code>") to serve as [=payment method identifiers=], while
 locating the actual [=payment method manifest=] at a different URL.
 
 For an example [=payment method=] AlicePay, with [=payment method identifier=]
-"<code>https://alicepay.com/</code>", a user agent would issue a GET request to that
+"<code>https://alicepay.com/</code>", a user agent would issue a HEAD request to that
 [=payment method identifier=] URL as follows:
 
 <pre>
-  GET / HTTP/2
+  HEAD / HTTP/2
   Host: alicepay.com
   User-Agent: Mellblomenator/9000
 </pre>
@@ -98,12 +98,11 @@ The server could then either respond with
 
 <pre>
   HTTP/2 204
-  Link: &lt;/pay/payment-manifest.json>; rel="payment-method-manifest"
+  Link: &lt;/pay/payment-manifest.json&gt;; rel="payment-method-manifest"
 </pre>
 
-to redirect the user agent to "<code>https://alicepay.com/pay/payment-manifest.json</code>", or
-could respond with the JSON contents of the payment method manifest directly in a
-<code>200</code>-status response.
+to redirect the user agent to
+"<code>https://alicepay.com/pay/payment-manifest.json</code>".
 
 <h3 id="manifest-example">Example manifest file</h3>
 
@@ -115,7 +114,7 @@ following [=payment method manifest=] file at
 {
   "default_applications": ["app/webappmanifest.json"],
   "supported_origins": [
-    "https://bobpay.xyz",
+    "https://bobbucks.dev",
     "https://alicepay.friendsofalice.example"
   ]
 }
@@ -259,7 +258,7 @@ contents of the corresponding manifest.
 1. Let |manifestsMap| be an empty [=map=].
 1. [=list/For each=] |identifierURL| of |identifierURLs|:
   1. Let |manifestURLString| be null.
-  1. Let |identifierRequest| be a new [=request=] whose [=request/method=] is `<code>GET</code>`,
+  1. Let |identifierRequest| be a new [=request=] whose [=request/method=] is `<code>HEAD</code>`,
      [=request/url=] is |identifierURL|, [=request/client=] is |client|, [=request/mode=] is
      "<code>cors</code>", [=request/credentials mode=] is "<code>omit</code>",
      [=request/redirect mode=] is "<code>error</code>", and [=request/referrer policy=] is

--- a/index.bs
+++ b/index.bs
@@ -395,6 +395,21 @@ algorithm will asynchronously complete with either a [=scalar value string=] or 
 
 <h2 id="security">Security and privacy considerations</h2>
 
+<h3 id="link-http-header-required">Link HTTP header requirement</h3>
+
+To enhance security and prevent potential misuse, this specification disallows hosting a payment
+method manifest directly at its payment method identifier URL. Instead, the manifest must be linked
+via a <code>Link</code> HTTP header.
+
+This design mitigates a security vulnerability that could arise on shared hosting platforms. If a
+manifest could be hosted directly at a URL, a user on a cloud-hosted domain could potentially
+register a service worker for the entire domain, using the just-in-time install functionality of
+<cite>Web Payment Handlers</cite>. [[PAYMENT-HANDLER]]
+
+By mandating the use of the <code>Link</code> HTTP header, control is given to the cloud hosting
+provider. The provider can configure their servers to prevent arbitrary users from installing
+service workers, thereby safeguarding their domain.
+
 <h3 id="revealing-to-providers">Revealing user activity to payment providers</h3>
 
 [=ingest payment method manifests|Ingesting payment method manifests=] might reveal information


### PR DESCRIPTION
Chromium initiates the download of a payment method manifest through HTTP HEAD and looks for the Link HTTP header:
https://crrev.com/c/4954394

This patch updates the specification to replace the HTTP GET with HTTP HEAD in the first request for the payment method manifest download. This aligns the specification more closely to the implementation in Chromium.

(Chromium and other user agents based on it are the only implementers of this specification at this time.)

Fixed: https://crbug.com/384016068


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rsolomakhin/payment-method-manifest/pull/48.html" title="Last updated on Jul 2, 2025, 4:30 PM UTC (a3af2e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-manifest/48/0986c9f...rsolomakhin:a3af2e1.html" title="Last updated on Jul 2, 2025, 4:30 PM UTC (a3af2e1)">Diff</a>